### PR TITLE
Add `source.env` to make npm run dev work

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The current goal is to make it work with the following generic features, so it c
 # install dependencies
 cd frontend
 nvm use
+cp frontend/example.env frontend/.env
+source frontend/.env
 npm install
 ```
 

--- a/frontend/example.env
+++ b/frontend/example.env
@@ -6,7 +6,7 @@ NUXT_ENV_RUN_MODE=dev
 NUXT_ENV_HOST=localhost
 NUXT_ENV_PORT_DEV=5000
 NUXT_ENV_PORT_PROD=5001
-NUXT_ENV_APP_TITLE=Data patch
+NUXT_ENV_APP_TITLE="Data patch"
 
 ### - - - - - - - - - - - - - - - - - - - - - ###
 ### LEGAL
@@ -23,7 +23,7 @@ NUXT_ENV_LEGAL_PROVIDER_SITE=...
 ### LOCALES / i18n
 ### - - - - - - - - - - - - - - - - - - - - - ###
 NUXT_ENV_LANG_DEFAULT_LOCALE=fr
-NUXT_ENV_LANG_DEFAULT_LOCALES=fr:Français:fr-FR.js,en:English:en-US.js
+NUXT_ENV_LANG_DEFAULT_LOCALES=fr:Français:fr-FR,en:English:en-US
 
 ### - - - - - - - - - - - - - - - - - - - - - ###
 ### API BACKEND / i18n
@@ -34,14 +34,14 @@ NUXT_API_ROOT_BACKEND_PROD=https://data-patch.io
 NUXT_API_ROOT_PREFIX=/api/v1/
 NUXT_API_ROOT_DOCUMENTATION=/api/docs
 
-NUXT_API_USERS=users/
-NUXT_API_GROUPS=groups/
-NUXT_API_WORKSPACES=workspaces/
-NUXT_API_DATASETS=datasets/
-NUXT_API_TABLES=tables/
-NUXT_API_TABLE_DATA=tabledata/
-NUXT_API_COMMENTS=comments/
-NUXT_API_NOTIFICATIONS=notifications/
+NUXT_API_USERS=users
+NUXT_API_GROUPS=groups
+NUXT_API_WORKSPACES=workspaces
+NUXT_API_DATASETS=datasets
+NUXT_API_TABLES=tables
+NUXT_API_TABLE_DATA=tabledata
+NUXT_API_COMMENTS=comments
+NUXT_API_NOTIFICATIONS=notifications
 
 
 ### - - - - - - - - - - - - - - - - - - - - - ###


### PR DESCRIPTION
The dotenv file is mandatory to have `npm run dev` working.
Also there were few mistakes in the example.env file